### PR TITLE
Remove ".post span" block in css

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -117,13 +117,6 @@ footer {
   margin-bottom: 25px;
 }
 
-.posts span {
-  float: right;
-  text-transform: uppercase;
-  font-size: 0.70em;
-  color: #777777;
-}
-
 .post {
   margin: auto;
   padding-bottom: 20px;


### PR DESCRIPTION
The ".post span" block in css is too broad that will interfere with many other libraries such as MathJax and KaTeX. The block is removed because there is no obvious reason for it to exist.

If the block is useful, the selector should be more specific. I can modify this PR to accommodate that.

Thanks!